### PR TITLE
Improve poll closing

### DIFF
--- a/src/instant_poll/command.clj
+++ b/src/instant_poll/command.clj
@@ -91,8 +91,9 @@
                                       :interaction-token token
                                       :creator-id user-id}
                                      close-in
-                                     (fn [{:keys [application-id interaction-token] :as poll}]
-                                       (discord/edit-original-interaction-response! discord-conn application-id interaction-token :components [])))]
+                                     (fn [{:keys [application-id interaction-token channel-id message-id] :as poll}]
+                                       (discord/edit-original-interaction-response! discord-conn application-id interaction-token :components [])
+                                       (discord/edit-message! discord-conn channel-id message-id :components [])))]
         (normal-response {:content (polls/render-poll poll (:bar-length config))
                           :components (make-components poll)})))))
 

--- a/src/instant_poll/command.clj
+++ b/src/instant_poll/command.clj
@@ -91,10 +91,11 @@
                                       :interaction-token token
                                       :creator-id user-id}
                                      close-in
-                                     (fn [{:keys [application-id interaction-token channel-id message-id] :as poll}]
-                                       (discord/edit-original-interaction-response! discord-conn application-id interaction-token :components [])
-                                       (discord/edit-message! discord-conn channel-id message-id :components [])))]
-        (normal-response {:content (polls/render-poll poll (:bar-length config))
+                                     (fn [{:keys [application-id interaction-token channel-id message-id close-timestamp] :as poll}]
+                                       (let [edits [:components [] :content (str (polls/render-poll poll (:bar-length config)) \newline (polls/close-notice poll false))]]
+                                         (apply discord/edit-original-interaction-response! discord-conn application-id interaction-token edits)
+                                         (apply discord/edit-message! discord-conn channel-id message-id edits))))]
+        (normal-response {:content (str (polls/render-poll poll (:bar-length config)) \newline (polls/close-notice poll true))
                           :components (make-components poll)})))))
 
 (defmethod handle-command ["poll" "help"]

--- a/src/instant_poll/component.clj
+++ b/src/instant_poll/component.clj
@@ -44,10 +44,10 @@
           (let [poll (polls/close-poll! poll-id)]
             (update-message-response
              {:content (str (polls/render-poll poll (:bar-length config)) \newline
-                            (discord-fmt/mention-user user-id) " closed this poll.")
+                            "Poll closed <t:" (quot (System/currentTimeMillis) 1000) ":R> by " (discord-fmt/mention-user user-id) \.)
               :components []}))
           (ephemeral-response {:content "You do not have permission to close this poll."}))
         (let [updated-poll (polls/toggle-vote! poll-id user-id option)]
           (swap! polls update poll-id assoc :channel-id channel-id :message-id message-id)
-          (update-message-response {:content (polls/render-poll updated-poll (:bar-length config))})))
+          (update-message-response {:content (str (polls/render-poll updated-poll (:bar-length config)) \newline (polls/close-notice updated-poll true))})))
       (ephemeral-response {:content "This poll isn't active anymore."}))))

--- a/src/instant_poll/poll.clj
+++ b/src/instant_poll/poll.clj
@@ -26,7 +26,7 @@
 (defn create-poll! [poll close-in close-action]
   (let [id (generate-poll-id id-length)
         poll (cond-> (assoc poll :votes {} :id id)
-               close-in (assoc :close-timestamp (+' (quot (System/currentTimeMillis) 1000) close-in)))]
+               (pos? close-in) (assoc :close-timestamp (+' (quot (System/currentTimeMillis) 1000) close-in)))]
     (swap! polls assoc id poll)
     (when (pos? close-in)
       (.schedule scheduler ^Runnable (fn [] (close-action (close-poll! id))) ^long close-in ^TimeUnit TimeUnit/SECONDS))

--- a/src/instant_poll/poll.clj
+++ b/src/instant_poll/poll.clj
@@ -25,7 +25,8 @@
 
 (defn create-poll! [poll close-in close-action]
   (let [id (generate-poll-id id-length)
-        poll (assoc poll :votes {} :id id)]
+        poll (cond-> (assoc poll :votes {} :id id)
+               close-in (assoc :close-timestamp (+' (quot (System/currentTimeMillis) 1000) close-in)))]
     (swap! polls assoc id poll)
     (when (pos? close-in)
       (.schedule scheduler ^Runnable (fn [] (close-action (close-poll! id))) ^long close-in ^TimeUnit TimeUnit/SECONDS))
@@ -73,3 +74,7 @@
      option-list
      option-results
      total-votes)))
+
+(defn close-notice [{:keys [close-timestamp] :as _poll} open?]
+  (when close-timestamp
+    (str "Poll close" (if open? \s \d) " <t:" close-timestamp ":R>")))


### PR DESCRIPTION
- Closes #2 
- Closes #8 

Polls can now always be closed properly using the close button. Polls can also be closed automatically (close-in) after 15 minutes if the app has the `bot` scope on the server. Additionally, timestamps were added to the rendering where appropriate.