### PR TITLE
Add persistence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ ARG jar=instant-poll-*-standalone.jar
 WORKDIR /usr/app/instant-poll
 COPY --from=build /usr/src/instant-poll/target/$jar .
 ENV jar=$jar
-CMD java -jar $jar
+CMD java -jar --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED $jar

--- a/config/config.edn.template
+++ b/config/config.edn.template
@@ -3,4 +3,6 @@
  ; The setting below configures how long the bars of the poll results are
  :bar-length 40
  ; Max length of custom option keys
- :max-key-length 20}
+ :max-key-length 20
+ ; Path to your database file
+ :db "./data"}

--- a/project.clj
+++ b/project.clj
@@ -17,6 +17,7 @@
   :main instant-poll.handler
   :aot :all
   :global-vars {*warn-on-reflection* true}
+  :jvm-opts ["--add-opens=java.base/java.nio=ALL-UNNAMED" "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"]
   :profiles
   {:dev {:dependencies [[javax.servlet/servlet-api "2.5"]
                         [ring/ring-mock "0.3.2"]]}})

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,8 @@
                  [mount "0.1.16"]
                  [org.suskalo/discljord "1.3.0"]
                  [com.github.johnnyjayjay/slash "0.3.0-SNAPSHOT"]
-                 [com.vdurmont/emoji-java "5.1.1"]]
+                 [com.vdurmont/emoji-java "5.1.1"]
+                 [datalevin "0.5.27"]]
   :main instant-poll.handler
   :aot :all
   :global-vars {*warn-on-reflection* true}

--- a/src/instant_poll/component.clj
+++ b/src/instant_poll/component.clj
@@ -1,12 +1,13 @@
 (ns instant-poll.component
   (:require [clojure.string :as string]
             [instant-poll.poll :as polls]
-            [instant-poll.state :refer [config polls]]
+            [instant-poll.state :refer [config polls db]]
             [discljord.util :refer [parse-if-str]]
             [discljord.formatting :as discord-fmt]
             [discljord.permissions :as discord-perms]
             [slash.component.structure :as cmp]
-            [slash.response :as rsp]))
+            [slash.response :as rsp]
+            [datalevin.core :as d]))
 
 (def action-separator "_")
 (def action-separator-pattern (re-pattern action-separator))
@@ -32,7 +33,7 @@
 (defmethod poll-action "vote"
   [_ {{{user-id :id} :user} :member {message-id :id :keys [channel-id]} :message :as _interaction} {:keys [id] :as _poll} [option]]
   (let [updated-poll (polls/toggle-vote! id user-id option)]
-    (swap! polls update id assoc :channel-id channel-id :message-id message-id)
+    (put-poll (assoc updated-poll :channel-id channel-id :message-id message-id))
     (rsp/update-message {:content (str (polls/render-poll updated-poll (:bar-length config)) \newline (polls/close-notice updated-poll true))})))
 
 (defmethod poll-action "show-votes"

--- a/src/instant_poll/component.clj
+++ b/src/instant_poll/component.clj
@@ -1,13 +1,12 @@
 (ns instant-poll.component
   (:require [clojure.string :as string]
             [instant-poll.poll :as polls]
-            [instant-poll.state :refer [config polls db]]
+            [instant-poll.state :refer [config]]
             [discljord.util :refer [parse-if-str]]
             [discljord.formatting :as discord-fmt]
             [discljord.permissions :as discord-perms]
             [slash.component.structure :as cmp]
-            [slash.response :as rsp]
-            [datalevin.core :as d]))
+            [slash.response :as rsp]))
 
 (def action-separator "_")
 (def action-separator-pattern (re-pattern action-separator))
@@ -33,7 +32,7 @@
 (defmethod poll-action "vote"
   [_ {{{user-id :id} :user} :member {message-id :id :keys [channel-id]} :message :as _interaction} {:keys [id] :as _poll} [option]]
   (let [updated-poll (polls/toggle-vote! id user-id option)]
-    (put-poll (assoc updated-poll :channel-id channel-id :message-id message-id))
+    (polls/put-poll! (assoc updated-poll :channel-id channel-id :message-id message-id))
     (rsp/update-message {:content (str (polls/render-poll updated-poll (:bar-length config)) \newline (polls/close-notice updated-poll true))})))
 
 (defmethod poll-action "show-votes"

--- a/src/instant_poll/poll.clj
+++ b/src/instant_poll/poll.clj
@@ -1,22 +1,23 @@
 (ns instant-poll.poll
   (:require [clojure.string :as string]
             [instant-poll.bar :as bar]
-            [instant-poll.state :refer [scheduler polls]])
+            [instant-poll.state :refer [scheduler db]]
+            [datalevin.core :as d])
   (:import (java.util.concurrent TimeUnit)))
 
+(defn put-poll! [poll]
+  (d/transact-kv db [[:put "polls" (:id poll) poll]]))
+
 (defn find-poll [poll-id]
-  (@polls poll-id))
+  (d/get-value db poll-id))
 
 (defn close-poll! [poll-id]
-  (-> polls
-      (swap-vals! dissoc poll-id)
-      first
-      (get poll-id)))
+  (doto (assoc (find-poll poll-id) :closed true) put-poll!))
 
 (defn create-poll! [id poll close-in close-action]
   (let [poll (cond-> (assoc poll :votes {} :id id)
                (pos? close-in) (assoc :close-timestamp (+' (quot (System/currentTimeMillis) 1000) close-in)))]
-    (swap! polls assoc id poll)
+    (put-poll! poll)
     (when (pos? close-in)
       (.schedule scheduler ^Runnable (fn [] (close-action (close-poll! id))) ^long close-in ^TimeUnit TimeUnit/SECONDS))
     poll))
@@ -34,7 +35,7 @@
       (empty? (get-in poll [:votes user])) (update :votes dissoc user))))
 
 (defn toggle-vote! [poll-id user option]
-  (get (swap! polls update poll-id toggle-vote user option) poll-id))
+  (doto (toggle-vote (find-poll poll-id) user option) put-poll!))
 
 (defn count-votes [options votes]
   (reduce-kv

--- a/src/instant_poll/poll.clj
+++ b/src/instant_poll/poll.clj
@@ -9,7 +9,7 @@
   (d/transact-kv db [[:put "polls" (:id poll) poll]]))
 
 (defn find-poll [poll-id]
-  (d/get-value db poll-id))
+  (d/get-value db "polls" poll-id))
 
 (defn close-poll! [poll-id]
   (doto (assoc (find-poll poll-id) :closed true) put-poll!))

--- a/src/instant_poll/state.clj
+++ b/src/instant_poll/state.clj
@@ -10,9 +10,6 @@
   :start (Executors/newSingleThreadScheduledExecutor)
   :stop (.shutdown ^ScheduledExecutorService scheduler))
 
-(defstate polls
-  :start (atom {}))
-
 (defstate config
   :start (edn/read-string (slurp (or (System/getenv "CONFIG") "config/config.edn"))))
 

--- a/src/instant_poll/state.clj
+++ b/src/instant_poll/state.clj
@@ -1,7 +1,8 @@
 (ns instant-poll.state
   (:require [clojure.edn :as edn]
             [mount.core :refer [defstate]]
-            [discljord.messaging :as discord])
+            [discljord.messaging :as discord]
+            [datalevin.core :as d])
   (:import (java.util.concurrent Executors ScheduledExecutorService)))
 
 
@@ -21,3 +22,7 @@
 
 (defstate app-id
   :start (:id @(discord/get-current-application-information! discord-conn)))
+
+(defstate db
+  :start (doto (d/open-kv (:db config)) (d/open-dbi "polls"))
+  :stop (d/close-kv db))


### PR DESCRIPTION
This PR adds persistence using a [datalevin](https://github.com/juji-io/datalevin) key-value store. This means polls are preserved beyond restarts now and "Show results" can be properly supported.
Closes #10 and also #5 (because it is now outdated).