### PR TITLE
Allow addition of options after creation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [com.github.johnnyjayjay/ring-discord-auth "1.0.1"]
                  [mount "0.1.16"]
                  [com.github.discljord/discljord "1.3.1"]
-                 [com.github.johnnyjayjay/slash "0.4.0-SNAPSHOT"]
+                 [com.github.johnnyjayjay/slash "0.5.0-SNAPSHOT"]
                  [com.vdurmont/emoji-java "5.1.1"]
                  [datalevin "0.5.27"]]
   :main instant-poll.handler

--- a/src/instant_poll/command.clj
+++ b/src/instant_poll/command.clj
@@ -1,7 +1,7 @@
 (ns instant-poll.command
   (:require [clojure.string :as string]
             [instant-poll.poll :as polls]
-            [instant-poll.component :refer [make-components max-options]]
+            [instant-poll.component :refer [make-components max-options estimate-size]]
             [discljord.messaging :as discord]
             [discljord.formatting :as dfmt]
             [instant-poll.state :refer [discord-conn config app-id]]
@@ -61,47 +61,70 @@
      :description desc
      :emoji emoji}))
 
+(defn not-on-guild? [guild-id]
+  (= 50001 (:code @(discord/get-guild! discord-conn guild-id))))
+
+(defn exceeds-15-min? [close-in]
+  (>= close-in (* 15 60)))
+
+(defn locked-response [app-id]
+  (-> {:content (str "For automatic poll closing after more than **15 minutes**, I need additional authorisation."
+                     "\nThis is because Discord doesn't let me edit my messages after a longer period of time anymore if I am not directly on your server.")
+       :components [(cmp/action-row
+                     (cmp/link-button
+                      (str "https://discord.com/api/oauth2/authorize?client_id=" app-id "&scope=bot")
+                      :label "Unlock auto-closing after 15 minutes"
+                      :emoji {:name "🔓"}))]}
+      rsp/channel-message))
+
+(def too-big-response
+  (-> {:content (str "Your poll is too big! :books:")} rsp/channel-message rsp/ephemeral))
+
+(def duplicate-key-response
+  (-> {:content "One of your options has the same key as another! They must all have unique keys. :key:"} rsp/channel-message rsp/ephemeral))
+
+(def dm-response
+  (-> {:content "I'm afraid there are not a lot of people you can ask questions here :smile:\n...Wait, how did you even get here?"} rsp/channel-message rsp/ephemeral))
+
+(defn command-options->poll-options [option-map max-key-length]
+  (let [options (->> option-map keys (filter (comp #(Character/isDigit ^char %) first name)) (map option-map) (map parse-option))
+        custom-keys? (and (not (:default-keys option-map)) (every? #(<= (count (:custom-key %)) max-key-length) options))
+        poll-options (map-indexed (partial apply-key-policy custom-keys?) options)]
+    poll-options))
+
+(defn close-callback
+  [{:keys [application-id interaction-token channel-id message-id] :as poll}]
+  (let [edits [:components [] :content (str (polls/render-poll poll (:bar-length config)) \newline (polls/close-notice poll false))]]
+    (apply discord/edit-original-interaction-response! discord-conn application-id interaction-token edits)
+    (apply discord/edit-message! discord-conn channel-id message-id edits)))
+
 (defhandler create-command
   ["create"]
   {:keys [application-id token guild-id id] {{user-id :id} :user} :member :as _interaction}
-  {:keys [question show-votes multi-vote close-in default-keys allow-add-options] :or {show-votes "never" multi-vote false close-in -1 default-keys false} :as option-map}
-  (cond
-    (nil? guild-id) (-> {:content "I'm afraid there are not a lot of people you can ask questions here :smile:"} rsp/channel-message rsp/ephemeral)
-    (> (->> option-map vals (filter string?) (map count) (reduce +)) 1500) (-> {:content (str "Your poll is too big! :books:")} rsp/channel-message rsp/ephemeral)
+  {:keys [question show-votes multi-vote close-in allow-add-options] :or {show-votes "never" multi-vote false close-in -1} :as option-map}
+  (let [poll-options (command-options->poll-options option-map (:max-key-length config))]
+    (cond
+      (nil? guild-id) dm-response
+      (< (count (set (map :key poll-options))) (count poll-options)) duplicate-key-response
+      (> (estimate-size question poll-options (:bar-length config)) 2000) too-big-response
+      (and (exceeds-15-min? close-in) (not-on-guild? guild-id)) (locked-response app-id)
 
-    :else
-    (let [options (->> option-map keys (filter (comp #(Character/isDigit ^char %) first name)) (map option-map) (map parse-option))
-          max-key-length (:max-key-length config)
-          custom-keys? (and (not default-keys) (every? #(<= (count (:custom-key %)) max-key-length) options))
-          poll-options (map-indexed (partial apply-key-policy custom-keys?) options)]
-      (if (< (count (set (map :key poll-options))) (count poll-options))
-        (-> {:content "One of your options has the same key as another! They must all have unique keys. :key:"} rsp/channel-message rsp/ephemeral)
-        (if (and (>= close-in (* 15 60)) (= 50001 (:code @(discord/get-guild! discord-conn guild-id))))
-          (-> {:content (str "For automatic poll closing after more than **15 minutes**, I need additional authorisation."
-                             "\nThis is because Discord doesn't let me edit my messages after a longer period of time anymore if I am not directly on your server.")
-               :components [(cmp/action-row
-                             (cmp/link-button (str "https://discord.com/api/oauth2/authorize?client_id=" app-id "&scope=bot")
-                                              :label "Unlock auto-closing after 15 minutes"
-                                              :emoji {:name "🔓"}))]}
-              rsp/channel-message)
-          (let [poll (polls/create-poll!
-                      id
-                      {:question question
-                       :options poll-options
-                       :show-votes (keyword show-votes)
-                       :multi-vote? multi-vote
-                       :allow-add-options? allow-add-options
-                       :application-id application-id
-                       :interaction-token token
-                       :creator-id user-id}
-                      close-in
-                      (fn [{:keys [application-id interaction-token channel-id message-id] :as poll}]
-                        (let [edits [:components [] :content (str (polls/render-poll poll (:bar-length config)) \newline (polls/close-notice poll false))]]
-                          (apply discord/edit-original-interaction-response! discord-conn application-id interaction-token edits)
-                          (apply discord/edit-message! discord-conn channel-id message-id edits))))]
-            (rsp/channel-message
-             {:content (str (polls/render-poll poll (:bar-length config)) \newline (polls/close-notice poll true))
-              :components (make-components poll)})))))))
+      :else
+      (let [poll (polls/create-poll!
+                  id
+                  {:question question
+                   :options poll-options
+                   :show-votes (keyword show-votes)
+                   :multi-vote? multi-vote
+                   :allow-add-options? allow-add-options
+                   :application-id application-id
+                   :interaction-token token
+                   :creator-id user-id}
+                  close-in
+                  close-callback)]
+        (rsp/channel-message
+         {:content (str (polls/render-poll poll (:bar-length config)) \newline (polls/close-notice poll true))
+          :components (make-components poll)})))))
 
 (defhandler help-command
   ["help"]

--- a/src/instant_poll/command.clj
+++ b/src/instant_poll/command.clj
@@ -93,7 +93,7 @@
       (< (count (set (map :key poll-options))) (count poll-options))
       (-> {:content "One of your options has the same key as another! They must all have unique keys. :key:"} rsp/channel-message rsp/ephemeral)
 
-      (> (estimate-size question poll-options (:bar-length config)) 2000)
+      (> (estimate-size question poll-options (:bar-length config)) 1950)
       (-> {:content (str "Your poll is too big! :books:")} rsp/channel-message rsp/ephemeral)
 
       (and (exceeds-15-min? close-in) (not-on-guild? guild-id))

--- a/src/instant_poll/command.clj
+++ b/src/instant_poll/command.clj
@@ -32,7 +32,7 @@
                     (cmd/choice "Votes are always visible" "always")
                     (cmd/choice "Votes are only visible after closing" "after-closing")])
        (cmd/option "multi-vote" "Whether users have multiple votes (default: false)" :boolean)
-       (cmd/option "allow-add-options" "Whether it should be possible to add more options after creating the poll" :boolean)
+       (cmd/option "allow-change-options" "Whether it should be possible to add and remove options after creating the poll" :boolean)
        (cmd/option "close-in" "A duration (in seconds) after which voting closes (default: no expiration)" :integer)
        (cmd/option "default-keys" "Whether to use the default option keys (A-O). This can improve formatting on mobile." :boolean)]))
     (cmd/sub-command "help" "Display help for this bot")
@@ -82,7 +82,7 @@
 (defhandler create-command
   ["create"]
   {:keys [application-id token guild-id id] {{user-id :id} :user} :member :as _interaction}
-  {:keys [question show-votes multi-vote close-in allow-add-options] :or {show-votes "never" multi-vote false close-in -1} :as option-map}
+  {:keys [question show-votes multi-vote close-in allow-change-options] :or {show-votes "never" multi-vote false close-in -1} :as option-map}
   (let [poll-options (command-options->poll-options option-map (:max-key-length config))]
     (cond
       (nil? guild-id)
@@ -106,7 +106,7 @@
                    :options poll-options
                    :show-votes (keyword show-votes)
                    :multi-vote? multi-vote
-                   :allow-add-options? allow-add-options
+                   :allow-change-options? allow-change-options
                    :application-id application-id
                    :interaction-token token
                    :creator-id user-id}

--- a/src/instant_poll/component.clj
+++ b/src/instant_poll/component.clj
@@ -71,6 +71,14 @@
       rsp/channel-message
       rsp/ephemeral))
 
+(defn estimate-size [question options bar-length]
+  (count (polls/render-poll
+          {:question question
+           :options options
+           :votes {"123" (set (map :key options))}
+           :multi-vote? true}
+          bar-length)))
+
 (defmethod poll-action "add-option"
   [_ {{{user-id :id} :user} :member :as _interaction} {:keys [creator-id options] :as _poll} _]
   (cond

--- a/src/instant_poll/component.clj
+++ b/src/instant_poll/component.clj
@@ -1,12 +1,16 @@
 (ns instant-poll.component
   (:require [clojure.string :as string]
             [instant-poll.poll :as polls]
-            [instant-poll.state :refer [config]]
+            [instant-poll.state :refer [config discord-conn app-id]]
             [discljord.util :refer [parse-if-str]]
             [discljord.formatting :as discord-fmt]
             [discljord.permissions :as discord-perms]
             [slash.component.structure :as cmp]
-            [slash.response :as rsp]))
+            [slash.response :as rsp]
+            [discljord.messaging :as discord])
+  (:import (com.vdurmont.emoji EmojiManager)))
+
+(def currently-updated? (atom false))
 
 (def max-options 15)
 
@@ -42,10 +46,12 @@
 (defmulti poll-action (fn [action _interaction _poll _options] action))
 
 (defmethod poll-action "vote"
-  [_ {{{user-id :id} :user} :member {message-id :id :keys [channel-id]} :message :as _interaction} {:keys [id] :as _poll} [option]]
-  (let [updated-poll (polls/toggle-vote! id user-id option)]
-    (polls/put-poll! (assoc updated-poll :channel-id channel-id :message-id message-id))
-    (rsp/update-message {:content (str (polls/render-poll updated-poll (:bar-length config)) \newline (polls/close-notice updated-poll true))})))
+  [_ {{{user-id :id} :user} :member :keys [token] :as _interaction} {:keys [id] :as poll} [option]]
+  (if @currently-updated?
+    (-> {:content "The poll was updated, please try again."} rsp/channel-message rsp/ephemeral)
+    (let [updated-poll (polls/toggle-vote (assoc poll :interaction-token token) user-id option)]
+      (polls/put-poll! updated-poll)
+      (rsp/update-message {:content (str (polls/render-poll updated-poll (:bar-length config)) \newline (polls/close-notice updated-poll true))}))))
 
 (defn group-by-votes [votes]
   (reduce-kv
@@ -79,7 +85,6 @@
            :multi-vote? true}
           bar-length)))
 
-
 (defn keys-only? [poll]
   (-> poll :options first :description nil?))
 
@@ -90,7 +95,7 @@
     (- 1920 (count (polls/render-poll updated bar-length)))))
 
 (defmethod poll-action "add-option"
-  [_ {{{user-id :id} :user} :member :as _interaction} {:keys [creator-id options] :as poll} _]
+  [_ {{{user-id :id} :user} :member :as _interaction} {:keys [id creator-id options] :as poll} _]
   (cond
     (not= user-id creator-id) (-> {:content "❌ Sorry, only the creator of this poll can add more options."} rsp/channel-message rsp/ephemeral)
     (> (count options) max-options) (-> {:content "❌ The maximum number of supported options has already been reached." rsp/channel-message rsp/ephemeral})
@@ -102,12 +107,53 @@
         (apply
          rsp/modal
          "Add a poll option"
-         "add-option-form"
-         (cmp/action-row (cmp/text-input :short "option-emoji" "Option emoji" :placeholder "🙂" :required false))
+         id
+         (cmp/action-row (cmp/text-input :short "emoji" "Option emoji" :placeholder "🙂" :required false))
          (if (keys-only? poll)
-           [(cmp/action-row (cmp/text-input :short "option-key" "Option key" :required true :max-length (min available max-key-length)))]
-           [(cmp/action-row (cmp/text-input :short "option-key" "Option key" :required true :max-length max-key-length))
-            (cmp/action-row (cmp/text-input :paragraph "option-description" "Option description" :required false :max-length available))]))))))
+           [(cmp/action-row (cmp/text-input :short "key" "Option key" :required true :max-length (min available max-key-length)))]
+           [(cmp/action-row (cmp/text-input :short "key" "Option key" :required true :max-length max-key-length))
+            (cmp/action-row (cmp/text-input :paragraph "description" "Option description" :required false :max-length available))]))))))
+
+(defn parse-emoji [^String emoji-str]
+  (let [[_ a name id :as match] (re-matches discord-fmt/emoji-mention emoji-str)]
+    (cond
+      (EmojiManager/isEmoji emoji-str) {:name emoji-str}
+      match {:animated (some? a)
+             :name name
+             :id id})))
+
+(defn unlock-message [feature app-id]
+  (-> {:content (str "For " feature " after more than **15 minutes** of inactivity, I need additional authorisation."
+                     "\nThis is because Discord doesn't let me edit my messages after a longer period of time anymore if I am not directly on your server.")
+       :components [(cmp/action-row
+                     (cmp/link-button
+                      (str "https://discord.com/api/oauth2/authorize?client_id=" app-id "&scope=bot")
+                      :label (str "Unlock " feature " after 15 minutes")
+                      :emoji {:name "🔓"}))]}
+      rsp/channel-message))
+
+(defn handle-add-option-form-submit
+  [{{:keys [components custom-id]} :data}]
+  (reset! currently-updated? true)
+  (let [option (->> components
+                    (map :components)
+                    (map first)
+                    (map (juxt (comp keyword :custom-id) :value))
+                    (into {}))
+        final-option (update option :emoji parse-emoji)
+        {:keys [id interaction-token channel-id message-id] :as poll} (update (polls/find-poll custom-id) :options conj final-option)
+        content (polls/render-poll poll (:bar-length config))
+        components (make-components poll)]
+    (try
+      (if (and
+           (= 50017 (:code @(discord/edit-original-interaction-response! discord-conn app-id interaction-token :content content :components components)))
+           (= 50001 (:code @(discord/edit-message! discord-conn channel-id message-id :content content :components components))))
+        (unlock-message "poll additions" app-id)
+        (do
+          (polls/put-poll! poll)
+          (-> {:content "Poll successfully updated!"} rsp/channel-message rsp/ephemeral)))
+      (finally
+        (reset! currently-updated? false)))))
 
 (defmethod poll-action "close"
   [_ {{{user-id :id} :user :keys [permissions]} :member :as _interaction} {:keys [id creator-id show-votes] :as _poll} _]
@@ -128,10 +174,12 @@
 
 (defn handle-button-press
   [{{:keys [custom-id]} :data
-    {{poll-id :id} :interaction} :message
+    {{poll-id :id} :interaction message-id :id :keys [channel-id]} :message
     :as interaction}]
   (if-let [poll (polls/find-poll poll-id)]
     (let [[action & options] (parse-custom-id custom-id)]
+      (when-not (:channel-id poll)
+        (polls/put-poll! (assoc poll :channel-id channel-id :message-id message-id)))
       (poll-action action interaction poll options))
     ;; if poll not found
     (-> {:content "This poll isn't active anymore."} rsp/channel-message rsp/ephemeral)))

--- a/src/instant_poll/component.clj
+++ b/src/instant_poll/component.clj
@@ -29,14 +29,14 @@
 (def close-poll-button
   (cmp/button :danger "close" :label "Close Poll" :emoji {:name "🔒"}))
 
-(defn make-components [{:keys [options show-votes allow-add-options?] :as _poll}]
+(defn make-components [{:keys [options show-votes allow-change-options?] :as _poll}]
   (concat
    (for [option-group (partition-all 5 options)]
      (apply
       cmp/action-row
       (for [{:keys [key emoji]} option-group]
         (cmp/button :primary (str "vote" action-separator key) :label key :emoji emoji))))
-   (when allow-add-options?
+   (when allow-change-options?
      [(cmp/action-row
        #_remove-option-button
        add-option-button)])

--- a/src/instant_poll/handler.clj
+++ b/src/instant_poll/handler.clj
@@ -5,7 +5,7 @@
             [ring-discord-auth.ring :refer [wrap-authenticate]]
             [instant-poll.state :refer [config]]
             [instant-poll.command :refer [handle-command]]
-            [instant-poll.component :refer [handle-button-press]]
+            [instant-poll.component :refer [handle-button-press handle-add-option-form-submit]]
             [mount.core :as mount]
             [org.httpkit.server :as http-server]
             [discljord.util :as discord-util]
@@ -15,7 +15,8 @@
 (def slash-handlers
   (assoc webhook-defaults
          :application-command #'handle-command
-         :message-component #'handle-button-press))
+         :message-component #'handle-button-press
+         :modal-submit #'handle-add-option-form-submit))
 
 (defn handler [{:keys [body]}]
   (response (slash/route-interaction slash-handlers body)))
@@ -26,7 +27,7 @@
 (defn -main [& _args]
   (mount/start)
   (http-server/run-server
-   (-> handler
+   (-> #'handler
       wrap-json-response
       wrap-clean-json
       wrap-json-body


### PR DESCRIPTION
Implements #12 and lays the ground work for *removing* options after the fact as well, although that is not implemented yet because selection menus are not supported in modal interactions yet.